### PR TITLE
Fix crash/freeze in Safari 13 when trying to open any dropdown selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .*swo
 overrides/*.scss
 Gemfile.lock
+.DS_Store

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -4898,7 +4898,6 @@ body {
   font-size: 14px;
   line-height: 1.4;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  text-rendering: optimizeLegibility;
   margin: 0;
   padding: 0;
   min-height: 100%; }


### PR DESCRIPTION
Starting from MacOS Safari 13.0.1 the issue appeared. Safari freezes or just crashes when trying to open any dropdown selector in Redmine using this theme. I had to remove the unsupported CSS field from stylesheet to resolve that.